### PR TITLE
CAN: don't use SYS_INIT as it will block forever if CAN bus is down

### DIFF
--- a/src/can.c
+++ b/src/can.c
@@ -778,7 +778,7 @@ struct thingset_can *thingset_can_get_inst()
     return &ts_can_single;
 }
 
-static int thingset_can_init()
+static void thingset_can_thread()
 {
     int err;
 
@@ -788,25 +788,14 @@ static int thingset_can_init()
         return err;
     }
 
-    return 0;
-}
-
-#ifdef CONFIG_ISOTP_FAST
-SYS_INIT(thingset_can_init, APPLICATION, THINGSET_INIT_PRIORITY_DEFAULT);
-#else
-static void thingset_can_thread()
-{
-    if (thingset_can_init() != 0) {
-        return;
-    }
-
+#ifndef CONFIG_ISOTP_FAST
     while (true) {
         thingset_can_process_inst(&ts_can_single, K_FOREVER);
     }
+#endif
 }
 
 K_THREAD_DEFINE(thingset_can, CONFIG_THINGSET_CAN_THREAD_STACK_SIZE, thingset_can_thread, NULL,
                 NULL, NULL, CONFIG_THINGSET_CAN_THREAD_PRIORITY, 0, 0);
-#endif /* CONFIG_ISOTP_FAST */
 
 #endif /* !CONFIG_THINGSET_CAN_MULTIPLE_INSTANCES */


### PR DESCRIPTION
If the CAN bus is down/disconnected, `thingset_can_init` blocks forever, so system initialisation never completes. This change moves initialisation back to the thread so that it does not block system initialisation. If the CAN bus is subsequently connected, the initialisation method will then complete.