### PR TITLE
CAN: Implement new bus numbering scheme

### DIFF
--- a/include/thingset/can.h
+++ b/include/thingset/can.h
@@ -150,7 +150,7 @@ struct thingset_can_request_response
 {
     struct k_sem sem;
     struct k_timer timer;
-    isotp_fast_can_id can_id;
+    uint32_t can_id;
     thingset_can_response_callback_t callback;
     void *cb_arg;
 };

--- a/include/thingset/isotp_fast.h
+++ b/include/thingset/isotp_fast.h
@@ -10,11 +10,6 @@
 #define ISOTP_MSG_FDF BIT(3)
 #endif
 
-/* Represents a sender or a receiver in an ISO-TP fixed addressing scheme */
-typedef uint8_t isotp_fast_node_id;
-/* ISO-TP message CAN ID */
-typedef uint32_t isotp_fast_can_id;
-
 /**
  * Callback invoked when a message is received.
  *
@@ -28,8 +23,8 @@ typedef uint32_t isotp_fast_can_id;
  * @param can_id The CAN ID of the message that has been received.
  * @param arg The value of @ref recv_cb_arg passed to @ref isotp_fast_bind.
  */
-typedef void (*isotp_fast_recv_callback_t)(struct net_buf *buffer, int rem_len,
-                                           isotp_fast_can_id can_id, void *arg);
+typedef void (*isotp_fast_recv_callback_t)(struct net_buf *buffer, int rem_len, uint32_t can_id,
+                                           void *arg);
 
 /**
  * Callback invoked when an error occurs during message receiption.
@@ -38,7 +33,7 @@ typedef void (*isotp_fast_recv_callback_t)(struct net_buf *buffer, int rem_len,
  * @param can_id The CAN ID of the sender of the message, if available.
  * @param arg The value of @ref recv_cb_arg passed to @ref isotp_fast_bind.
  */
-typedef void (*isotp_fast_recv_error_callback_t)(int8_t error, isotp_fast_can_id can_id, void *arg);
+typedef void (*isotp_fast_recv_error_callback_t)(int8_t error, uint32_t can_id, void *arg);
 
 /**
  * Callback invoked when a message has been sent.
@@ -82,7 +77,7 @@ struct isotp_fast_ctx
     /** Callback that is invoked when a message is sent */
     isotp_fast_send_callback_t sent_callback;
     /** CAN ID of this node, used in both transmission and receipt of messages */
-    isotp_fast_can_id rx_can_id;
+    uint32_t rx_can_id;
 #ifdef CONFIG_ISOTP_FAST_BLOCKING_RECEIVE
     sys_slist_t wait_recv_list;
 #endif
@@ -107,7 +102,7 @@ struct isotp_fast_ctx
  * @returns 0 on success, otherwise an error code < 0.
  */
 int isotp_fast_bind(struct isotp_fast_ctx *ctx, const struct device *can_dev,
-                    const isotp_fast_can_id rx_can_id, const struct isotp_fast_opts *opts,
+                    const uint32_t rx_can_id, const struct isotp_fast_opts *opts,
                     isotp_fast_recv_callback_t recv_callback, void *recv_cb_arg,
                     isotp_fast_recv_error_callback_t recv_error_callback,
                     isotp_fast_send_callback_t sent_callback);
@@ -144,4 +139,4 @@ int isotp_fast_recv(struct isotp_fast_ctx *ctx, struct can_filter sender, uint8_
  * @returns 0 on success.
  */
 int isotp_fast_send(struct isotp_fast_ctx *ctx, const uint8_t *data, size_t len,
-                    const isotp_fast_node_id target_addr, void *sent_cb_arg);
+                    const uint8_t target_addr, void *sent_cb_arg);

--- a/include/thingset/isotp_fast.h
+++ b/include/thingset/isotp_fast.h
@@ -133,10 +133,11 @@ int isotp_fast_recv(struct isotp_fast_ctx *ctx, struct can_filter sender, uint8_
  * @param target_addr The node ID identifying the recipient. This will be
  *                    combined with the sending address @ref my_addr on @ref
  *                    ctx to form the CAN ID on the message.
+ * @param target_bus Target bus number (4-bit value) to send the message to.
  * @param sent_cb_arg A pointer to data to be supplied to the callback
  *                    that will be invoked when the message is sent.
  *
  * @returns 0 on success.
  */
 int isotp_fast_send(struct isotp_fast_ctx *ctx, const uint8_t *data, size_t len,
-                    const uint8_t target_addr, void *sent_cb_arg);
+                    const uint8_t target_addr, uint8_t target_bus, void *sent_cb_arg);

--- a/src/Kconfig.can
+++ b/src/Kconfig.can
@@ -68,11 +68,27 @@ config THINGSET_CAN_PACKETIZED_REPORTS_FRAME_TX_INTERVAL
 
 config THINGSET_CAN_MULTIPLE_INSTANCES
     bool "Support for multiple ThingSet CAN instances"
+    depends on ISOTP_FAST
     help
       If enabled, the CAN message processing does not happen in the
       background anymore. Instead, each instance has to be initialized
       for a dedicated CAN device and and messages have to be processed
       manually in application threads.
+
+      The bus numbering scheme in the CAN ID is not compatible with
+      the current Zephyr upstream ISO-TP implementation, so it depends
+      on ISOTP_FAST.
+
+config THINGSET_CAN_BUS_NUMBER
+    int "ThingSet CAN bus number"
+    depends on !THINGSET_CAN_MULTIPLE_INSTANCES
+    range 0 15
+    default 0
+    help
+      The bus number can be used to identify multiple CAN buses in one system.
+      It is used by gateways to forward messages between different buses.
+
+      For a single bus system, the default bus number 0 should be used.
 
 config THINGSET_CAN_RESPONSE_DELAY
     int "ThingSet CAN response delay"

--- a/src/can.c
+++ b/src/can.c
@@ -436,8 +436,7 @@ int thingset_can_send_inst(struct thingset_can *ts_can, uint8_t *tx_buf, size_t 
     }
 }
 
-void isotp_fast_recv_callback(struct net_buf *buffer, int rem_len, isotp_fast_can_id can_id,
-                              void *arg)
+void isotp_fast_recv_callback(struct net_buf *buffer, int rem_len, uint32_t can_id, void *arg)
 {
     struct thingset_can *ts_can = arg;
 
@@ -460,7 +459,7 @@ void isotp_fast_recv_callback(struct net_buf *buffer, int rem_len, isotp_fast_ca
             int tx_len =
                 thingset_process_message(&ts, ts_can->rx_buffer, len, sbuf->data, sbuf->size);
             if (tx_len > 0) {
-                isotp_fast_node_id target_id = (uint8_t)(can_id & 0xFF);
+                uint8_t target_id = (uint8_t)(can_id & 0xFF);
                 int err = thingset_can_send_inst(ts_can, sbuf->data, tx_len, target_id, NULL, NULL,
                                                  K_NO_WAIT);
                 if (err != 0) {
@@ -474,7 +473,7 @@ void isotp_fast_recv_callback(struct net_buf *buffer, int rem_len, isotp_fast_ca
     }
 }
 
-void isotp_fast_recv_error_callback(int8_t error, isotp_fast_can_id can_id, void *arg)
+void isotp_fast_recv_error_callback(int8_t error, uint32_t can_id, void *arg)
 {
     LOG_ERR("RX error %d", error);
 }
@@ -690,8 +689,8 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
     }
 
 #ifdef CONFIG_ISOTP_FAST
-    isotp_fast_can_id rx_can_id = THINGSET_CAN_TYPE_CHANNEL | THINGSET_CAN_PRIO_CHANNEL
-                                  | THINGSET_CAN_TARGET_SET(ts_can->node_addr);
+    uint32_t rx_can_id = THINGSET_CAN_TYPE_CHANNEL | THINGSET_CAN_PRIO_CHANNEL
+                         | THINGSET_CAN_TARGET_SET(ts_can->node_addr);
     isotp_fast_bind(&ts_can->ctx, can_dev, rx_can_id, &fc_opts, isotp_fast_recv_callback, ts_can,
                     isotp_fast_recv_error_callback, isotp_fast_sent_callback);
 #endif

--- a/src/isotp_fast_internal.h
+++ b/src/isotp_fast_internal.h
@@ -31,9 +31,9 @@
  */
 struct isotp_fast_send_ctx
 {
-    sys_snode_t node;            /**< linked list node in @ref isotp_send_ctx_list */
-    struct isotp_fast_ctx *ctx;  /**< pointer to bound context */
-    isotp_fast_can_id tx_can_id; /**< CAN ID used on sent message frames */
+    sys_snode_t node;           /**< linked list node in @ref isotp_send_ctx_list */
+    struct isotp_fast_ctx *ctx; /**< pointer to bound context */
+    uint32_t tx_can_id;         /**< CAN ID used on sent message frames */
     struct k_work work;
     struct k_timer timer;          /**< handles timeouts */
     struct k_sem sem;              /**< used to ensure CF frames are sent in order */
@@ -55,9 +55,9 @@ struct isotp_fast_send_ctx
  */
 struct isotp_fast_recv_ctx
 {
-    sys_snode_t node;            /**< linked list node in @ref isotp_recv_ctx_list */
-    struct isotp_fast_ctx *ctx;  /**< pointer to bound context */
-    isotp_fast_can_id rx_can_id; /**< CAN ID on received frames */
+    sys_snode_t node;           /**< linked list node in @ref isotp_recv_ctx_list */
+    struct isotp_fast_ctx *ctx; /**< pointer to bound context */
+    uint32_t rx_can_id;         /**< CAN ID on received frames */
     struct k_work work;
     struct k_timer timer;   /**< handles timeouts */
     struct net_buf *buffer; /**< head node of buffer */
@@ -85,17 +85,12 @@ struct isotp_fast_recv_await_ctx
     struct isotp_fast_recv_ctx *rctx;
 };
 
-static inline isotp_fast_node_id isotp_fast_get_source_addr(isotp_fast_can_id can_id)
+static inline uint8_t isotp_fast_get_source_addr(uint32_t can_id)
 {
-    return (isotp_fast_node_id)(can_id & ISOTP_FIXED_ADDR_SA_MASK);
+    return (uint8_t)(can_id & ISOTP_FIXED_ADDR_SA_MASK);
 }
 
-static inline isotp_fast_node_id isotp_fast_get_frame_source(struct can_frame *frame)
+static inline uint8_t isotp_fast_get_target_addr(uint32_t can_id)
 {
-    return (isotp_fast_node_id)(frame->id & ISOTP_FIXED_ADDR_SA_MASK);
-}
-
-static inline isotp_fast_node_id isotp_fast_get_target_addr(isotp_fast_can_id can_id)
-{
-    return (isotp_fast_node_id)((can_id & ISOTP_FIXED_ADDR_TA_MASK) >> ISOTP_FIXED_ADDR_TA_POS);
+    return (uint8_t)((can_id & ISOTP_FIXED_ADDR_TA_MASK) >> ISOTP_FIXED_ADDR_TA_POS);
 }

--- a/src/isotp_fast_internal.h
+++ b/src/isotp_fast_internal.h
@@ -94,3 +94,13 @@ static inline uint8_t isotp_fast_get_target_addr(uint32_t can_id)
 {
     return (uint8_t)((can_id & ISOTP_FIXED_ADDR_TA_MASK) >> ISOTP_FIXED_ADDR_TA_POS);
 }
+
+static inline uint8_t isotp_fast_get_source_bus(uint32_t can_id)
+{
+    return (uint8_t)((can_id & 0x000F0000) >> 16);
+}
+
+static inline uint8_t isotp_fast_get_target_bus(uint32_t can_id)
+{
+    return (uint8_t)((can_id & 0x00F00000) >> 20);
+}

--- a/tests/can/src/main.c
+++ b/tests/can/src/main.c
@@ -25,8 +25,7 @@ uint8_t *response;
 size_t response_len;
 int response_code;
 
-static void isotp_fast_recv_cb(struct net_buf *buffer, int rem_len, isotp_fast_can_id rx_can_id,
-                               void *arg)
+static void isotp_fast_recv_cb(struct net_buf *buffer, int rem_len, uint32_t rx_can_id, void *arg)
 {
     response = malloc(buffer->len);
     memcpy(response, buffer->data, buffer->len);

--- a/tests/can/src/main.c
+++ b/tests/can/src/main.c
@@ -86,9 +86,9 @@ ZTEST(thingset_can, test_send_request_to_node)
     zassert_false(err < 0, "adding rx filter failed: %d", err);
 
 #ifdef CONFIG_ISOTP_FAST
-    thingset_can_send(req_buf, sizeof(req_buf), 0xCC, NULL, NULL, TEST_RECEIVE_TIMEOUT);
+    thingset_can_send(req_buf, sizeof(req_buf), 0xCC, 0x0, NULL, NULL, TEST_RECEIVE_TIMEOUT);
 #else
-    thingset_can_send(req_buf, sizeof(req_buf), 0xCC);
+    thingset_can_send(req_buf, sizeof(req_buf), 0xCC, 0x0);
 #endif
 
     err = k_sem_take(&request_tx_sem, TEST_RECEIVE_TIMEOUT);
@@ -111,7 +111,7 @@ ZTEST(thingset_can, test_request_response)
     zassert_equal(err, 0, "bind fail");
 
     uint8_t msg[] = { 0x01, 0x1e };
-    err = isotp_fast_send(&client_ctx, msg, sizeof(msg), 0x01, NULL);
+    err = isotp_fast_send(&client_ctx, msg, sizeof(msg), 0x01, 0x0, NULL);
     zassert_equal(err, 0, "send fail");
     k_sem_take(&request_tx_sem, TEST_RECEIVE_TIMEOUT);
 

--- a/tests/isotp_fast/conformance/src/async_recv.h
+++ b/tests/isotp_fast/conformance/src/async_recv.h
@@ -56,8 +56,7 @@ static int blocking_recv(uint8_t *buf, size_t size, k_timeout_t timeout)
     return rx_len;
 }
 
-void isotp_fast_recv_handler(struct net_buf *buffer, int rem_len, isotp_fast_can_id rx_can_id,
-                             void *arg)
+void isotp_fast_recv_handler(struct net_buf *buffer, int rem_len, uint32_t rx_can_id, void *arg)
 {
     struct recv_msg msg = {
         .len = buffer->len,
@@ -70,7 +69,7 @@ void isotp_fast_recv_handler(struct net_buf *buffer, int rem_len, isotp_fast_can
     k_msgq_put(&recv_msgq, &msg, K_NO_WAIT);
 }
 
-void isotp_fast_recv_error_handler(int8_t error, isotp_fast_can_id rx_can_id, void *arg)
+void isotp_fast_recv_error_handler(int8_t error, uint32_t rx_can_id, void *arg)
 {
     // printk("Error %d received\n", error);
     recv_last_error = error;

--- a/tests/isotp_fast/conformance/src/main.c
+++ b/tests/isotp_fast/conformance/src/main.c
@@ -40,7 +40,7 @@ static void send_sf(void)
 {
     int ret;
 
-    ret = isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_addr, NULL);
+    ret = isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_addr, rx_bus_id, NULL);
     zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -68,7 +68,7 @@ static void send_test_data(const uint8_t *data, size_t len)
 {
     int ret;
 
-    ret = isotp_fast_send(&ctx, data, len, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
+    ret = isotp_fast_send(&ctx, data, len, rx_node_addr, rx_bus_id, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -254,8 +254,8 @@ ZTEST(isotp_fast_conformance, test_send_sf_fixed)
     filter_id = add_rx_msgq(tx_can_id, CAN_EXT_ID_MASK);
     zassert_true((filter_id >= 0), "Negative filter number [%d]", filter_id);
 
-    ret =
-        isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
+    ret = isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_addr, rx_bus_id,
+                          INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 
     check_frame_series(&des_frame, 1, &frame_msgq);
@@ -487,7 +487,7 @@ ZTEST(isotp_fast_conformance, test_send_timeouts)
     /* Test timeout for first FC*/
     k_sem_reset(&send_compl_sem);
     start_time = k_uptime_get_32();
-    isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr,
+    isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr, rx_bus_id,
                     INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
     ret = k_sem_take(&send_compl_sem, K_MSEC(BS_TIMEOUT_UPPER_MS));
     time_diff = k_uptime_get_32() - start_time;
@@ -496,7 +496,7 @@ ZTEST(isotp_fast_conformance, test_send_timeouts)
 
     /* Test timeout for consecutive FC frames */
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr,
+    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr, rx_bus_id,
                           INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
     zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
@@ -511,7 +511,7 @@ ZTEST(isotp_fast_conformance, test_send_timeouts)
 
     /* Test timeout reset with WAIT frame */
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr,
+    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr, rx_bus_id,
                           INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
     zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
@@ -667,7 +667,7 @@ ZTEST(isotp_fast_conformance, test_sender_fc_errors)
     fc_frame.length = DATA_SIZE_FC;
 
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr,
+    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr, rx_bus_id,
                           INT_TO_POINTER(ISOTP_N_INVALID_FS));
     zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
@@ -679,12 +679,12 @@ ZTEST(isotp_fast_conformance, test_sender_fc_errors)
     /* buffer overflow */
     can_remove_rx_filter(can_dev, filter_id);
 
-    ret = isotp_fast_send(&ctx, random_data, 5 * 1024, rx_node_addr, NULL);
+    ret = isotp_fast_send(&ctx, random_data, 5 * 1024, rx_node_addr, rx_bus_id, NULL);
     zassert_equal(ret, ISOTP_N_BUFFER_OVERFLW, "Expected overflow but got %d", ret);
     filter_id = add_rx_msgq(tx_can_id, CAN_EXT_ID_MASK);
 
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr,
+    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr, rx_bus_id,
                           INT_TO_POINTER(ISOTP_N_BUFFER_OVERFLW));
 
     check_frame_series(&ff_frame, 1, &frame_msgq);
@@ -695,7 +695,7 @@ ZTEST(isotp_fast_conformance, test_sender_fc_errors)
 
     /* wft overrun */
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr,
+    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr, rx_bus_id,
                           INT_TO_POINTER(ISOTP_N_WFT_OVRN));
 
     check_frame_series(&ff_frame, 1, &frame_msgq);
@@ -722,7 +722,8 @@ ZTEST(isotp_fast_conformance, test_sf_length)
     filter_id = add_rx_msgq(tx_can_id, CAN_EXT_ID_MASK);
     zassert_true((filter_id >= 0), "Negative filter number [%d]", filter_id);
 
-    ret = isotp_fast_send(&ctx, random_data, 7, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
+    ret =
+        isotp_fast_send(&ctx, random_data, 7, rx_node_addr, rx_bus_id, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 
     check_frame_series(&des_frame, 1, &frame_msgq);
@@ -732,7 +733,8 @@ ZTEST(isotp_fast_conformance, test_sf_length)
     memcpy(&des_frame.data[2], random_data, DATA_SIZE_SF);
     des_frame.length = 9;
 
-    ret = isotp_fast_send(&ctx, random_data, 9, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
+    ret =
+        isotp_fast_send(&ctx, random_data, 9, rx_node_addr, rx_bus_id, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 
     check_frame_series(&des_frame, 1, &frame_msgq);

--- a/tests/isotp_fast/conformance/src/main.c
+++ b/tests/isotp_fast/conformance/src/main.c
@@ -40,7 +40,7 @@ static void send_sf(void)
 {
     int ret;
 
-    ret = isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_id, NULL);
+    ret = isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_addr, NULL);
     zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -68,7 +68,7 @@ static void send_test_data(const uint8_t *data, size_t len)
 {
     int ret;
 
-    ret = isotp_fast_send(&ctx, data, len, rx_node_id, INT_TO_POINTER(ISOTP_N_OK));
+    ret = isotp_fast_send(&ctx, data, len, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -254,7 +254,8 @@ ZTEST(isotp_fast_conformance, test_send_sf_fixed)
     filter_id = add_rx_msgq(tx_can_id, CAN_EXT_ID_MASK);
     zassert_true((filter_id >= 0), "Negative filter number [%d]", filter_id);
 
-    ret = isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_id, INT_TO_POINTER(ISOTP_N_OK));
+    ret =
+        isotp_fast_send(&ctx, random_data, DATA_SIZE_SF, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 
     check_frame_series(&des_frame, 1, &frame_msgq);
@@ -486,7 +487,7 @@ ZTEST(isotp_fast_conformance, test_send_timeouts)
     /* Test timeout for first FC*/
     k_sem_reset(&send_compl_sem);
     start_time = k_uptime_get_32();
-    isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_id,
+    isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr,
                     INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
     ret = k_sem_take(&send_compl_sem, K_MSEC(BS_TIMEOUT_UPPER_MS));
     time_diff = k_uptime_get_32() - start_time;
@@ -495,7 +496,7 @@ ZTEST(isotp_fast_conformance, test_send_timeouts)
 
     /* Test timeout for consecutive FC frames */
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_id,
+    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr,
                           INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
     zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
@@ -510,7 +511,7 @@ ZTEST(isotp_fast_conformance, test_send_timeouts)
 
     /* Test timeout reset with WAIT frame */
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_id,
+    ret = isotp_fast_send(&ctx, random_data, sizeof(random_data), rx_node_addr,
                           INT_TO_POINTER(ISOTP_N_TIMEOUT_BS));
     zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
@@ -666,7 +667,7 @@ ZTEST(isotp_fast_conformance, test_sender_fc_errors)
     fc_frame.length = DATA_SIZE_FC;
 
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_id,
+    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr,
                           INT_TO_POINTER(ISOTP_N_INVALID_FS));
     zassert_equal(ret, ISOTP_N_OK, "Send returned %d", ret);
 
@@ -678,12 +679,12 @@ ZTEST(isotp_fast_conformance, test_sender_fc_errors)
     /* buffer overflow */
     can_remove_rx_filter(can_dev, filter_id);
 
-    ret = isotp_fast_send(&ctx, random_data, 5 * 1024, rx_node_id, NULL);
+    ret = isotp_fast_send(&ctx, random_data, 5 * 1024, rx_node_addr, NULL);
     zassert_equal(ret, ISOTP_N_BUFFER_OVERFLW, "Expected overflow but got %d", ret);
     filter_id = add_rx_msgq(tx_can_id, CAN_EXT_ID_MASK);
 
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_id,
+    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr,
                           INT_TO_POINTER(ISOTP_N_BUFFER_OVERFLW));
 
     check_frame_series(&ff_frame, 1, &frame_msgq);
@@ -694,7 +695,7 @@ ZTEST(isotp_fast_conformance, test_sender_fc_errors)
 
     /* wft overrun */
     k_sem_reset(&send_compl_sem);
-    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_id,
+    ret = isotp_fast_send(&ctx, random_data, DATA_SEND_LENGTH, rx_node_addr,
                           INT_TO_POINTER(ISOTP_N_WFT_OVRN));
 
     check_frame_series(&ff_frame, 1, &frame_msgq);
@@ -721,7 +722,7 @@ ZTEST(isotp_fast_conformance, test_sf_length)
     filter_id = add_rx_msgq(tx_can_id, CAN_EXT_ID_MASK);
     zassert_true((filter_id >= 0), "Negative filter number [%d]", filter_id);
 
-    ret = isotp_fast_send(&ctx, random_data, 7, rx_node_id, INT_TO_POINTER(ISOTP_N_OK));
+    ret = isotp_fast_send(&ctx, random_data, 7, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 
     check_frame_series(&des_frame, 1, &frame_msgq);
@@ -731,7 +732,7 @@ ZTEST(isotp_fast_conformance, test_sf_length)
     memcpy(&des_frame.data[2], random_data, DATA_SIZE_SF);
     des_frame.length = 9;
 
-    ret = isotp_fast_send(&ctx, random_data, 9, rx_node_id, INT_TO_POINTER(ISOTP_N_OK));
+    ret = isotp_fast_send(&ctx, random_data, 9, rx_node_addr, INT_TO_POINTER(ISOTP_N_OK));
     zassert_equal(ret, 0, "Send returned %d", ret);
 
     check_frame_series(&des_frame, 1, &frame_msgq);

--- a/tests/isotp_fast/conformance/src/main.h
+++ b/tests/isotp_fast/conformance/src/main.h
@@ -72,11 +72,10 @@ const struct isotp_fast_opts fc_opts = {
 #endif
 };
 
-const isotp_fast_can_id rx_can_id = 0x18DA0201;
-const isotp_fast_can_id tx_can_id = 0x18DA0102;
+const uint32_t rx_can_id = 0x18DA0201;
+const uint32_t tx_can_id = 0x18DA0102;
 
-const isotp_fast_node_id rx_node_id = 0x01;
-const isotp_fast_node_id tx_node_id = 0x02;
+const uint8_t rx_node_addr = 0x01;
 
 const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 struct isotp_fast_ctx ctx;

--- a/tests/isotp_fast/conformance/src/main.h
+++ b/tests/isotp_fast/conformance/src/main.h
@@ -72,10 +72,11 @@ const struct isotp_fast_opts fc_opts = {
 #endif
 };
 
-const uint32_t rx_can_id = 0x18DA0201;
-const uint32_t tx_can_id = 0x18DA0102;
+const uint32_t rx_can_id = 0x180A0201;
+const uint32_t tx_can_id = 0x18A00102;
 
 const uint8_t rx_node_addr = 0x01;
+const uint8_t rx_bus_id = 0xA;
 
 const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 struct isotp_fast_ctx ctx;

--- a/tests/isotp_fast/conformance/src/sync_recv.h
+++ b/tests/isotp_fast/conformance/src/sync_recv.h
@@ -15,9 +15,8 @@ static int blocking_recv(uint8_t *buf, size_t size, k_timeout_t timeout)
     return isotp_fast_recv(&ctx, sender, buf, size, timeout);
 }
 
-void isotp_fast_recv_handler(struct net_buf *buffer, int rem_len, isotp_fast_can_id can_id,
-                             void *arg)
+void isotp_fast_recv_handler(struct net_buf *buffer, int rem_len, uint32_t can_id, void *arg)
 {}
 
-void isotp_fast_recv_error_handler(int8_t error, isotp_fast_can_id can_id, void *arg)
+void isotp_fast_recv_error_handler(int8_t error, uint32_t can_id, void *arg)
 {}

--- a/tests/isotp_fast/conformance/testcase.yaml
+++ b/tests/isotp_fast/conformance/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  thingset_sdk.isotp_fast.conformance.sync.fd:
+  thingset_sdk.isotp_fast.conformance.sync:
     tags:
       - can
       - isotp


### PR DESCRIPTION
This PR implements the new bus numbering scheme to overcome issues with overlapping filters for gateways.

Related specification update: https://github.com/ThingSet/thingset.github.io/issues/25