### PR TITLE
CAN: Add bridge routing and fix some ISO-TP issues

### DIFF
--- a/include/canbus/isotp_fast.h
+++ b/include/canbus/isotp_fast.h
@@ -74,8 +74,8 @@ typedef void (*isotp_fast_send_callback_t)(int result, void *arg);
  * @param ctx Pointer to the main context.
  * @param addr Address.
  */
-typedef struct isotp_fast_addr (*isotp_fast_get_tx_addr_callback_t)(struct isotp_fast_ctx *ctx,
-                                                                    struct isotp_fast_addr addr);
+typedef struct isotp_fast_addr (*isotp_fast_get_tx_addr_callback_t)(
+    const struct isotp_fast_addr *addr);
 #endif /* CONFIG_ISOTP_FAST_CUSTOM_ADDRESSING */
 
 /**
@@ -221,7 +221,7 @@ int isotp_fast_send(struct isotp_fast_ctx *ctx, const uint8_t *data, size_t len,
  *
  * @returns resulting address
  */
-struct isotp_fast_addr isotp_fast_get_counterpart_addr(const struct isotp_fast_addr *addr);
+struct isotp_fast_addr isotp_fast_get_tx_addr_fixed(const struct isotp_fast_addr *addr);
 
 /**
  * Send a message to a given recipient. If the message fits within a

--- a/include/canbus/isotp_fast.h
+++ b/include/canbus/isotp_fast.h
@@ -216,14 +216,6 @@ int isotp_fast_send(struct isotp_fast_ctx *ctx, const uint8_t *data, size_t len,
 #ifdef CONFIG_ISOTP_FAST_FIXED_ADDRESSING
 
 /**
- * Create the counterpart address from a given fixed address by swapping the target
- * address and the source address.
- *
- * @returns resulting address
- */
-struct isotp_fast_addr isotp_fast_get_tx_addr_fixed(const struct isotp_fast_addr *addr);
-
-/**
  * Send a message to a given recipient. If the message fits within a
  * CAN frame, it will be sent synchronously. If not, it will be sent
  * asynchronously.

--- a/include/thingset/can.h
+++ b/include/thingset/can.h
@@ -239,21 +239,6 @@ struct thingset_can
 #ifdef CONFIG_THINGSET_CAN_MULTIPLE_INSTANCES
 
 /**
- * Wait for incoming ThingSet message (usually requests)
- *
- * @param ts_can Pointer to the thingset_can context.
- * @param rx_buf Buffer to store the message.
- * @param rx_buf_size Size of the buffer to store the message.
- * @param source_addr Pointer to store the node address the data was received from.
- * @param source_bus Pointer to store the bus number the data was received from.
- * @param timeout Timeout to wait for a message from the node.
- *
- * @returns length of message or negative errno in case of error
- */
-int thingset_can_receive_inst(struct thingset_can *ts_can, uint8_t *rx_buf, size_t rx_buf_size,
-                              uint8_t *source_addr, uint8_t *source_bus, k_timeout_t timeout);
-
-/**
  * Send ThingSet report to the CAN bus.
  *
  * @param ts_can Pointer to the thingset_can context.

--- a/src/Kconfig.can
+++ b/src/Kconfig.can
@@ -7,6 +7,7 @@ menuconfig THINGSET_CAN
     depends on ISOTP_FAST
     depends on ENTROPY_GENERATOR
     select EVENTS
+    select ISOTP_FAST_CUSTOM_ADDRESSING
 
 if THINGSET_CAN
 
@@ -95,6 +96,36 @@ config THINGSET_CAN_CONTROL_REPORTING_PERIOD
     depends on THINGSET_CAN_CONTROL_REPORTING
     default 100
 
+choice THINGSET_CAN_ROUTING
+    prompt "Message routing scheme"
+    default THINGSET_CAN_ROUTING_BUSES
+    help
+      Select how frames should be routed between different buses.
+
+config THINGSET_CAN_ROUTING_BUSES
+    bool "Bus numbers"
+    depends on ISOTP_FAST
+    select ISOTP_FAST_CUSTOM_ADDRESSING
+    help
+      Bits 16-23 of the CAN ID are used for a target bus (higher nibble) and a
+      source bus (lower nibble).
+
+      Buses should be used to allow message routing from one bus to any other bus.
+      There is no hierarchy between the buses.
+
+config THINGSET_CAN_ROUTING_BRIDGES
+    bool "Bridge numbers"
+    select ISOTP_FAST_FIXED_ADDRESSING
+    help
+      Bits 16-23 of the CAN ID are used to define a bridge number between 1 and
+      255. Each bridge defines the connection between two fixed buses. Bridge
+      number 0 is reserved local communication on the same bus (i.e. no routing).
+
+      Bridges should be used if the maximum amount of 16 buses is not
+      sufficient. Otherwise, routing using bus numbers are more simple and generic.
+
+endchoice
+
 config THINGSET_CAN_MULTIPLE_INSTANCES
     bool "Support for multiple ThingSet CAN instances"
     depends on ISOTP_FAST
@@ -108,16 +139,17 @@ config THINGSET_CAN_MULTIPLE_INSTANCES
       the current Zephyr upstream ISO-TP implementation, so it depends
       on ISOTP_FAST.
 
-config THINGSET_CAN_BUS_NUMBER
-    int "ThingSet CAN bus number"
+config THINGSET_CAN_DEFAULT_ROUTE
+    int "ThingSet CAN default route"
     depends on !THINGSET_CAN_MULTIPLE_INSTANCES
-    range 0 15
+    range 0 15 if THINGSET_CAN_ROUTING_BUSES
+    range 0 255 if THINGSET_CAN_ROUTING_BRIDGES
     default 0
     help
-      The bus number can be used to identify multiple CAN buses in one system.
-      It is used by gateways to forward messages between different buses.
+      The bus or bridge number (depending on THINGSET_CAN_ROUTING choice) is
+      used to route messages between different buses.
 
-      For a single bus system, the default bus number 0 should be used.
+      For a single bus system, the default 0 should be used.
 
 config THINGSET_CAN_RESPONSE_DELAY
     int "ThingSet CAN response delay"

--- a/src/can.c
+++ b/src/can.c
@@ -433,7 +433,7 @@ int thingset_can_send_inst(struct thingset_can *ts_can, uint8_t *tx_buf, size_t 
         k_timer_init(&ts_can->request_response.timer, thingset_can_request_response_timeout_handler,
                      NULL);
         k_timer_start(&ts_can->request_response.timer, timeout, timeout);
-        ts_can->request_response.can_id = isotp_fast_get_counterpart_addr(&tx_addr).ext_id;
+        ts_can->request_response.can_id = isotp_fast_get_tx_addr_fixed(&tx_addr).ext_id;
     }
 
     int ret = isotp_fast_send(&ts_can->ctx, tx_buf, tx_len, tx_addr, ts_can);
@@ -506,15 +506,15 @@ void isotp_fast_sent_callback(int result, void *arg)
     }
 }
 
-static struct isotp_fast_addr thingset_can_get_tx_addr_callback(struct isotp_fast_ctx *ctx,
-                                                                struct isotp_fast_addr rx_addr)
+static struct isotp_fast_addr
+thingset_can_get_tx_addr_callback(const struct isotp_fast_addr *rx_addr)
 {
     return (struct isotp_fast_addr){
-        .ext_id = (rx_addr.ext_id & 0x1F000000)
-                  | THINGSET_CAN_TARGET_BUS_SET(THINGSET_CAN_SOURCE_BUS_GET(rx_addr.ext_id))
-                  | THINGSET_CAN_SOURCE_BUS_SET(THINGSET_CAN_TARGET_BUS_GET(rx_addr.ext_id))
-                  | THINGSET_CAN_SOURCE_SET(THINGSET_CAN_TARGET_GET(rx_addr.ext_id))
-                  | THINGSET_CAN_TARGET_SET(THINGSET_CAN_SOURCE_GET(rx_addr.ext_id)),
+        .ext_id = (rx_addr->ext_id & 0x1F000000)
+                  | THINGSET_CAN_TARGET_BUS_SET(THINGSET_CAN_SOURCE_BUS_GET(rx_addr->ext_id))
+                  | THINGSET_CAN_SOURCE_BUS_SET(THINGSET_CAN_TARGET_BUS_GET(rx_addr->ext_id))
+                  | THINGSET_CAN_SOURCE_SET(THINGSET_CAN_TARGET_GET(rx_addr->ext_id))
+                  | THINGSET_CAN_TARGET_SET(THINGSET_CAN_SOURCE_GET(rx_addr->ext_id)),
     };
 }
 

--- a/subsys/canbus/isotp_fast/isotp_fast_internal.h
+++ b/subsys/canbus/isotp_fast/isotp_fast_internal.h
@@ -86,3 +86,15 @@ struct isotp_fast_recv_await_ctx
     struct isotp_fast_recv_ctx *rctx;
 };
 #endif
+
+#ifdef CONFIG_ISOTP_FAST_FIXED_ADDRESSING
+
+/**
+ * Create the counterpart address from a given fixed address by swapping the target
+ * address and the source address.
+ *
+ * @returns resulting address
+ */
+struct isotp_fast_addr isotp_fast_get_tx_addr_fixed(const struct isotp_fast_addr *addr);
+
+#endif

--- a/tests/can/src/main.c
+++ b/tests/can/src/main.c
@@ -67,15 +67,14 @@ static void item_rx_callback(uint16_t data_id, const uint8_t *value, size_t valu
     }
 }
 
-static struct isotp_fast_addr get_tx_addr_callback(struct isotp_fast_ctx *ctx,
-                                                   struct isotp_fast_addr rx_addr)
+static struct isotp_fast_addr get_tx_addr_callback(const struct isotp_fast_addr *rx_addr)
 {
     return (struct isotp_fast_addr){
-        .ext_id = (rx_addr.ext_id & 0x1F000000)
-                  | THINGSET_CAN_TARGET_BUS_SET(THINGSET_CAN_SOURCE_BUS_GET(rx_addr.ext_id))
-                  | THINGSET_CAN_SOURCE_BUS_SET(THINGSET_CAN_TARGET_BUS_GET(rx_addr.ext_id))
-                  | THINGSET_CAN_SOURCE_SET(THINGSET_CAN_TARGET_GET(rx_addr.ext_id))
-                  | THINGSET_CAN_TARGET_SET(THINGSET_CAN_SOURCE_GET(rx_addr.ext_id)),
+        .ext_id = (rx_addr->ext_id & 0x1F000000)
+                  | THINGSET_CAN_TARGET_BUS_SET(THINGSET_CAN_SOURCE_BUS_GET(rx_addr->ext_id))
+                  | THINGSET_CAN_SOURCE_BUS_SET(THINGSET_CAN_TARGET_BUS_GET(rx_addr->ext_id))
+                  | THINGSET_CAN_SOURCE_SET(THINGSET_CAN_TARGET_GET(rx_addr->ext_id))
+                  | THINGSET_CAN_TARGET_SET(THINGSET_CAN_SOURCE_GET(rx_addr->ext_id)),
     };
 }
 static void report_rx_callback(const uint8_t *buf, size_t len, uint8_t source_addr)


### PR DESCRIPTION
The bus numbering scheme introduced in #11 only supports up to 16 different buses in a system.

This PR adds an alternative routing method based on bridges. One bridge defines routing between exactly two buses. If it is not required to send data from any bus to any other bus, the bridge concept allows to have more buses in one system, especially if the bus layout is hierarchical. The maximum number of bridges is 255.

The existing routing based on bus numbers is selected as the default. The bridge-based routing is enabled with `CONFIG_THINGSET_CAN_ROUTING_BRIDGES`.

In addition to the implementation of the bridge routing, some clean-ups and bugfixes for ISO-TP are included in the PR.