### PR TITLE
EEPROM storage: Add simple unit tests

### DIFF
--- a/tests/storage_eeprom/CMakeLists.txt
+++ b/tests/storage_eeprom/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(thingset_sdk_storage_eeprom_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/storage_eeprom/boards/native_posix.overlay
+++ b/tests/storage_eeprom/boards/native_posix.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) The ThingSet Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		thingset,eeprom = &eeprom0;
+	};
+};

--- a/tests/storage_eeprom/boards/native_posix_64.overlay
+++ b/tests/storage_eeprom/boards/native_posix_64.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) The ThingSet Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		thingset,eeprom = &eeprom0;
+	};
+};

--- a/tests/storage_eeprom/boards/native_sim.conf
+++ b/tests/storage_eeprom/boards/native_sim.conf
@@ -1,0 +1,7 @@
+# Copyright (c) The ThingSet Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_EMUL=y
+CONFIG_I2C=y
+CONFIG_I2C_EMUL=y
+CONFIG_EEPROM_AT2X_EMUL=y

--- a/tests/storage_eeprom/boards/native_sim.overlay
+++ b/tests/storage_eeprom/boards/native_sim.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) The ThingSet Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		thingset,eeprom = &eeprom1;
+	};
+
+};
+
+&i2c0 {
+	status = "okay";
+	eeprom1: eeprom@53 {
+		status = "okay";
+		compatible = "atmel,at24";
+		reg=<0x53>;
+		size = <DT_SIZE_K(64)>;
+		timeout = <5>;
+		pagesize = <16>;
+		address-width = <16>;
+	};
+};

--- a/tests/storage_eeprom/prj.conf
+++ b/tests/storage_eeprom/prj.conf
@@ -1,0 +1,17 @@
+# Copyright (c) The ThingSet Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+CONFIG_ZTEST_SUMMARY=n
+
+CONFIG_EEPROM=y
+CONFIG_ENTROPY_GENERATOR=y
+
+CONFIG_THINGSET=y
+CONFIG_THINGSET_SDK=y
+CONFIG_THINGSET_SDK_LOG_LEVEL_DBG=y
+CONFIG_THINGSET_STORAGE=y
+
+# enable click-able absolute paths in assert messages
+CONFIG_BUILD_OUTPUT_STRIP_PATHS=n

--- a/tests/storage_eeprom/src/main.c
+++ b/tests/storage_eeprom/src/main.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) The ThingSet Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+
+#include <zephyr/ztest.h>
+
+#include <thingset.h>
+#include <thingset/sdk.h>
+#include <thingset/storage.h>
+
+/* test data objects */
+static float test_float = 1234.56F;
+static char test_string[] = "Hello World!";
+
+THINGSET_ADD_GROUP(THINGSET_ID_ROOT, 0x200, "Test", THINGSET_NO_CALLBACK);
+THINGSET_ADD_ITEM_FLOAT(0x200, 0x201, "wFloat", &test_float, 1, THINGSET_ANY_RW, TS_SUBSET_NVM);
+THINGSET_ADD_ITEM_STRING(0x200, 0x202, "wString", test_string, sizeof(test_string), THINGSET_ANY_RW,
+                         TS_SUBSET_NVM);
+
+ZTEST(thingset_storage_eeprom, test_save_load)
+{
+    int err;
+
+    err = thingset_storage_save();
+    zassert_equal(err, 0);
+
+    /* change above values */
+    test_float = 0.0F;
+    test_string[0] = ' ';
+
+    err = thingset_storage_load();
+    zassert_equal(err, 0);
+
+    /* check if values were properly restored */
+    zassert_equal(test_float, 1234.56F);
+    zassert_mem_equal(test_string, "Hello World!", sizeof(test_string));
+}
+
+static void *thingset_storage_eeprom_setup(void)
+{
+    thingset_init_global(&ts);
+
+    return NULL;
+}
+
+ZTEST_SUITE(thingset_storage_eeprom, NULL, thingset_storage_eeprom_setup, NULL, NULL, NULL);

--- a/tests/storage_eeprom/testcase.yaml
+++ b/tests/storage_eeprom/testcase.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  thingset_sdk.storage_eeprom:
+    integration_platforms:
+      - native_posix_64
+    platform_exclude:
+      # native sim with at24 emul EEPROM currently fails for unknown reasons
+      - native_sim
+    extra_args: EXTRA_CFLAGS=-Werror


### PR DESCRIPTION
The emulated at24 EEPROM with `native_sim` fails for unknown reasons, so I disabled it for CI, but kept the code.