### PR TITLE
Storage: Use multiple attempts to load data

### DIFF
--- a/src/Kconfig.storage
+++ b/src/Kconfig.storage
@@ -25,6 +25,15 @@ config THINGSET_STORAGE_FLASH
 
 endchoice
 
+config THINGSET_STORAGE_LOAD_ATTEMPTS
+    int "Maximum number of attempts to load data from storage at boot"
+    range 1 100
+    default 3
+    help
+      Depending on the environment, loading data from e.g. an I2C EEPROM may fail occasionally with
+      bad CRCs due to noise in the communication. This Kconfig defines how often reading from the
+      storage should be retried.
+
 config THINGSET_STORAGE_CHANGE
     bool "Store data upon change to ThingSet stored items"
     default y

--- a/src/sdk.c
+++ b/src/sdk.c
@@ -168,7 +168,15 @@ static int thingset_sdk_init(void)
 #endif
 
 #ifdef CONFIG_THINGSET_STORAGE
-    thingset_storage_load();
+    int err;
+    for (int i = 1; i <= CONFIG_THINGSET_STORAGE_LOAD_ATTEMPTS; i++) {
+        err = thingset_storage_load();
+        if (err == 0) {
+            break;
+        }
+        LOG_WRN("Loading data from storage failed (attempt %d/%d)", i,
+                CONFIG_THINGSET_STORAGE_LOAD_ATTEMPTS);
+    }
     thingset_set_update_callback(&ts, TS_SUBSET_NVM, thingset_storage_save_queued);
 #endif
 


### PR DESCRIPTION
 Depending on the environment, loading data from e.g. an I2C EEPROM may fail occasionally with bad CRCs due to noise in the communication.

This PR allows to attempt to read the data multiple times and makes the number of attempts configurable via Kconfig.