### PR TITLE
EEPROM: Add option to store data twice to improve reliability

### DIFF
--- a/src/Kconfig.storage
+++ b/src/Kconfig.storage
@@ -70,4 +70,12 @@ config THINGSET_STORAGE_EEPROM_PROGRESSIVE_IMPORT_EXPORT
 	  When enabled, allows the loading and saving of data larger than the shared buffer
 	  in EEPROM.
 
+config THINGSET_STORAGE_EEPROM_DUPLICATE
+	bool "Write EEPROM data twice to recover from power failures"
+	depends on THINGSET_STORAGE_EEPROM
+	help
+	  Divides the available EEPROM memory into two equal sections and writes the data into both
+	  sections each time. This allows to recover from power failures because at least one
+	  section will always have valid data.
+
 endif # THINGSET_STORAGE

--- a/tests/storage_eeprom/src/main.c
+++ b/tests/storage_eeprom/src/main.c
@@ -6,11 +6,14 @@
 
 #include <stdlib.h>
 
+#include <zephyr/drivers/eeprom.h>
 #include <zephyr/ztest.h>
 
 #include <thingset.h>
 #include <thingset/sdk.h>
 #include <thingset/storage.h>
+
+#define EEPROM_DEVICE_NODE DT_CHOSEN(thingset_eeprom)
 
 /* test data objects */
 static float test_float = 1234.56F;
@@ -20,6 +23,18 @@ THINGSET_ADD_GROUP(THINGSET_ID_ROOT, 0x200, "Test", THINGSET_NO_CALLBACK);
 THINGSET_ADD_ITEM_FLOAT(0x200, 0x201, "wFloat", &test_float, 1, THINGSET_ANY_RW, TS_SUBSET_NVM);
 THINGSET_ADD_ITEM_STRING(0x200, 0x202, "wString", test_string, sizeof(test_string), THINGSET_ANY_RW,
                          TS_SUBSET_NVM);
+
+static void corrupt_data()
+{
+    const struct device *eeprom_dev = DEVICE_DT_GET(EEPROM_DEVICE_NODE);
+    int err;
+
+    uint8_t zeros[4] = { 0 };
+
+    /* write some zeros behind the header to make the CRC calculation fail */
+    err = eeprom_write(eeprom_dev, 8, zeros, sizeof(zeros));
+    zassert_equal(err, 0, "Failed to corrupt the data");
+}
 
 ZTEST(thingset_storage_eeprom, test_save_load)
 {
@@ -38,6 +53,31 @@ ZTEST(thingset_storage_eeprom, test_save_load)
     /* check if values were properly restored */
     zassert_equal(test_float, 1234.56F);
     zassert_mem_equal(test_string, "Hello World!", sizeof(test_string));
+}
+
+ZTEST(thingset_storage_eeprom, test_save_load_corrupted)
+{
+    int err;
+
+    err = thingset_storage_save();
+    zassert_equal(err, 0);
+
+    /* change above values */
+    test_float = 0.0F;
+    test_string[0] = ' ';
+
+    corrupt_data();
+
+    err = thingset_storage_load();
+#ifdef CONFIG_THINGSET_STORAGE_EEPROM_DUPLICATE
+    zassert_equal(err, 0);
+
+    /* check if values were properly restored */
+    zassert_equal(test_float, 1234.56F);
+    zassert_mem_equal(test_string, "Hello World!", sizeof(test_string));
+#else
+    zassert_not_equal(err, 0);
+#endif
 }
 
 static void *thingset_storage_eeprom_setup(void)

--- a/tests/storage_eeprom/testcase.yaml
+++ b/tests/storage_eeprom/testcase.yaml
@@ -8,6 +8,15 @@ tests:
       # native sim with at24 emul EEPROM currently fails for unknown reasons
       - native_sim
     extra_args: EXTRA_CFLAGS=-Werror
+  thingset_sdk.storage_eeprom.duplicate:
+    integration_platforms:
+      - native_posix_64
+    platform_exclude:
+      # native sim with at24 emul EEPROM currently fails for unknown reasons
+      - native_sim
+    extra_args: EXTRA_CFLAGS=-Werror
+    extra_configs:
+      - CONFIG_THINGSET_STORAGE_EEPROM_DUPLICATE=y
   thingset_sdk.storage_eeprom.progressive:
     integration_platforms:
       - native_posix_64
@@ -17,3 +26,13 @@ tests:
     extra_args: EXTRA_CFLAGS=-Werror
     extra_configs:
       - CONFIG_THINGSET_STORAGE_EEPROM_PROGRESSIVE_IMPORT_EXPORT=y
+  thingset_sdk.storage_eeprom.progressive_duplicate:
+    integration_platforms:
+      - native_posix_64
+    platform_exclude:
+      # native sim with at24 emul EEPROM currently fails for unknown reasons
+      - native_sim
+    extra_args: EXTRA_CFLAGS=-Werror
+    extra_configs:
+      - CONFIG_THINGSET_STORAGE_EEPROM_PROGRESSIVE_IMPORT_EXPORT=y
+      - CONFIG_THINGSET_STORAGE_EEPROM_DUPLICATE=y


### PR DESCRIPTION
If enabled, the available EEPROM memory is divided into two equal sections and that data is always written to both sections each time. This allows to recover from power failures because at least one section will always have valid data.