### PR TITLE
EEPROM writes should be verified

### DIFF
--- a/src/Kconfig.storage
+++ b/src/Kconfig.storage
@@ -85,4 +85,12 @@ config THINGSET_STORAGE_EEPROM_DUPLICATE
 	  sections each time. This allows to recover from power failures because at least one
 	  section will always have valid data.
 
+config THINGSET_STORAGE_EEPROM_CHUNK_SIZE
+	int "Size of chunk when reading from/writing to EEPROM"
+	default 128
+	depends on THINGSET_STORAGE_EEPROM
+	help
+		When reading from or writing to EEPROM, transfer the data in chunks of this size.
+		This may resolve issues related to limitations with the I2C bus.
+
 endif # THINGSET_STORAGE

--- a/src/Kconfig.storage
+++ b/src/Kconfig.storage
@@ -90,7 +90,7 @@ config THINGSET_STORAGE_EEPROM_CHUNK_SIZE
 	default 128
 	depends on THINGSET_STORAGE_EEPROM
 	help
-		When reading from or writing to EEPROM, transfer the data in chunks of this size.
-		This may resolve issues related to limitations with the I2C bus.
+	  When reading from or writing to EEPROM, transfer the data in chunks of this size.
+	  This may resolve issues related to limitations with the I2C bus.
 
 endif # THINGSET_STORAGE

--- a/src/storage_eeprom.c
+++ b/src/storage_eeprom.c
@@ -197,17 +197,18 @@ static int thingset_eeprom_save(off_t offset, size_t useable_size)
                                    &sbuf->data[i * CONFIG_THINGSET_STORAGE_EEPROM_CHUNK_SIZE],
                                    write_size);
                 if (err) {
+                    LOG_DBG("Write error %d", -err);
                     continue;
                 }
                 err = eeprom_read(eeprom_dev, offset + chunk_offset, &read_back, write_size);
                 if (err) {
-                    LOG_DBG("Read back error");
+                    LOG_DBG("Read error %d", -err);
                     continue;
                 }
                 err = memcmp(&sbuf->data[i * CONFIG_THINGSET_STORAGE_EEPROM_CHUNK_SIZE], read_back,
                              write_size);
                 if (err) {
-                    LOG_DBG("Comparison failed error");
+                    LOG_DBG("Verify error %d", err);
                     continue;
                 }
                 else {
@@ -216,6 +217,7 @@ static int thingset_eeprom_save(off_t offset, size_t useable_size)
             }
             if (err) {
                 LOG_ERR("Error %d writing EEPROM.", -err);
+                break;
             }
             chunk_offset += write_size;
         }


### PR DESCRIPTION
Verifies EEPROM writes and chunks them using the same size as used for reads.