### PR TITLE
CAN: Consider bus/bridge for address claiming and add callback

### DIFF
--- a/include/thingset/can.h
+++ b/include/thingset/can.h
@@ -194,6 +194,14 @@ extern "C" {
 #define THINGSET_CAN_REQRESP(id) ((id & THINGSET_CAN_TYPE_MASK) == THINGSET_CAN_TYPE_REQRESP)
 
 /**
+ * Callback typedef for received address claim frames from other nodes
+ *
+ * @param eui64 The EUI-64 of the node used for the address claim message.
+ * @param source_addr Node address the address claim was received from
+ */
+typedef void (*thingset_can_addr_claim_rx_callback_t)(const uint8_t eui64[8], uint8_t source_addr);
+
+/**
  * Callback typedef for received multi-frame reports (type 0x1) via CAN
  *
  * @param report_buf Pointer to the buffer containing the received report (text or binary format)
@@ -247,6 +255,7 @@ struct thingset_can
     struct k_work_delayable control_reporting_work;
 #endif
     struct k_work_delayable addr_claim_work;
+    thingset_can_addr_claim_rx_callback_t addr_claim_callback;
     struct isotp_fast_ctx ctx;
     struct k_sem report_tx_sem;
     struct k_event events;
@@ -301,6 +310,15 @@ int thingset_can_send_inst(struct thingset_can *ts_can, uint8_t *tx_buf, size_t 
                            uint8_t target_addr, uint8_t route,
                            thingset_can_reqresp_callback_t callback, void *callback_arg,
                            k_timeout_t timeout);
+
+/**
+ * Set callback for received address claim frames from other nodes
+ *
+ * @param ts_can Pointer to the thingset_can context.
+ * @param cb Callback function.
+ */
+void thingset_can_set_addr_claim_rx_callback_inst(struct thingset_can *ts_can,
+                                                  thingset_can_addr_claim_rx_callback_t cb);
 
 #ifdef CONFIG_THINGSET_CAN_REPORT_RX
 /**

--- a/src/can.c
+++ b/src/can.c
@@ -168,8 +168,14 @@ static void thingset_can_addr_claim_rx_cb(const struct device *dev, struct can_f
             THINGSET_CAN_SOURCE_GET(frame->id), data[0], data[1], data[2], data[3], data[4],
             data[5], data[6], data[7]);
 
-    if (ts_can->node_addr == THINGSET_CAN_SOURCE_GET(frame->id)) {
+    uint8_t source_addr = THINGSET_CAN_SOURCE_GET(frame->id);
+
+    if (ts_can->node_addr == source_addr) {
         k_event_post(&ts_can->events, EVENT_ADDRESS_ALREADY_USED);
+    }
+
+    if (ts_can->addr_claim_callback != NULL) {
+        ts_can->addr_claim_callback(data, source_addr);
     }
 
     /* Optimization: store in internal database to exclude from potentially available addresses */
@@ -724,6 +730,12 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
 #endif
 
     return 0;
+}
+
+void thingset_can_set_addr_claim_rx_callback_inst(struct thingset_can *ts_can,
+                                                  thingset_can_addr_claim_rx_callback_t cb)
+{
+    ts_can->addr_claim_callback = cb;
 }
 
 #ifdef CONFIG_THINGSET_CAN_REPORT_RX


### PR DESCRIPTION
The callback can be used by an application to track which nodes have entered the bus.

See commit messages for further details.