### PR TITLE
Initialise err to 0 to avoid -Wmaybe-uninitialized

### DIFF
--- a/src/storage_eeprom.c
+++ b/src/storage_eeprom.c
@@ -159,7 +159,7 @@ out:
 
 static int thingset_eeprom_save(off_t offset, size_t useable_size)
 {
-    int err;
+    int err = 0;
 
     struct shared_buffer *sbuf = thingset_sdk_shared_buffer();
     k_sem_take(&sbuf->lock, K_FOREVER);


### PR DESCRIPTION
Simple change to prevent this warning message

```
thingset-zephyr-sdk/src/storage_eeprom.c:227:22: warning: 'err' may be used uninitialized [-Wmaybe-uninitialized]
  227 |     } while (rtn > 0 && err == 0);
```