### PR TITLE
Added option to use task PID for EUI seed under native POSIX

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -62,6 +62,10 @@ config THINGSET_GENERATE_NODE_ID
 	select CRC
 	default y
 
+config THINGSET_PID_EUI
+	bool "Use task PID as EUI basis for EUI generation"
+	depends on THINGSET_GENERATE_NODE_ID
+
 config THINGSET_NODE_NAME
 	string "Default ThingSet node name"
 	default "ThingSet Node"

--- a/Kconfig
+++ b/Kconfig
@@ -65,6 +65,7 @@ config THINGSET_GENERATE_NODE_ID
 config THINGSET_PID_EUI
 	bool "Use task PID as EUI basis for EUI generation"
 	depends on THINGSET_GENERATE_NODE_ID
+	depends on BOARD_NATIVE_POSIX
 
 config THINGSET_NODE_NAME
 	string "Default ThingSet node name"

--- a/src/sdk.c
+++ b/src/sdk.c
@@ -17,9 +17,9 @@
 #include <thingset.h>
 #include <thingset/sdk.h>
 
-#ifdef CONFIG_BOARD_NATIVE_POSIX
+#ifdef CONFIG_THINGSET_PID_EUI
 #include <unistd.h>
-#endif /* CONFIG_BOARD_NATIVE_POSIX */
+#endif
 
 LOG_MODULE_REGISTER(thingset_sdk, CONFIG_THINGSET_SDK_LOG_LEVEL);
 
@@ -123,10 +123,19 @@ static void generate_device_eui()
 #ifndef CONFIG_BOARD_NATIVE_POSIX
     hwinfo_get_device_id(buf, sizeof(buf));
 #else
+
+#ifndef CONFIG_THINGSET_PID_EUI
+    /* hwinfo is not available in native_posix, so we use random data instead */
+    for (int i = 0; i < sizeof(buf); i++) {
+        buf[i] = sys_rand32_get() & 0xFF;
+    }
+#else
     /* hwinfo is not available in native_posix, so we take task PID instead */
     int pid = getpid();
 
     snprintk(buf, sizeof(buf), "%X", pid);
+#endif
+
 #endif
 
     crc = crc32_ieee(buf, 8);

--- a/src/sdk.c
+++ b/src/sdk.c
@@ -17,6 +17,10 @@
 #include <thingset.h>
 #include <thingset/sdk.h>
 
+#ifdef CONFIG_BOARD_NATIVE_POSIX
+#include <unistd.h>
+#endif /* CONFIG_BOARD_NATIVE_POSIX */
+
 LOG_MODULE_REGISTER(thingset_sdk, CONFIG_THINGSET_SDK_LOG_LEVEL);
 
 /*
@@ -119,10 +123,10 @@ static void generate_device_eui()
 #ifndef CONFIG_BOARD_NATIVE_POSIX
     hwinfo_get_device_id(buf, sizeof(buf));
 #else
-    /* hwinfo is not available in native_posix, so we use random data instead */
-    for (int i = 0; i < sizeof(buf); i++) {
-        buf[i] = sys_rand32_get() & 0xFF;
-    }
+    /* hwinfo is not available in native_posix, so we take task PID instead */
+    int pid = getpid();
+
+    snprintk(buf, sizeof(buf), "%X", pid);
 #endif
 
     crc = crc32_ieee(buf, 8);


### PR DESCRIPTION
sys_rand32_get() seems to return the same sequence when spooling up multiple thingset duplicate POSIX applications. This uses the task PID instead.  