### PR TITLE
Add can device name to address claim printout

### DIFF
--- a/src/can.c
+++ b/src/can.c
@@ -685,7 +685,7 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
             if (err_cnt_after.tx_err_cnt <= err_cnt_before.tx_err_cnt) {
                 /* address claiming is finished */
                 k_event_post(&ts_can->events, EVENT_ADDRESS_CLAIMING_FINISHED);
-                LOG_INF("Using CAN node address 0x%.2X", ts_can->node_addr);
+                LOG_INF("Using CAN node address 0x%.2X on %s", ts_can->node_addr, ts_can->dev->name);
                 break;
             }
 

--- a/src/can.c
+++ b/src/can.c
@@ -685,7 +685,8 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
             if (err_cnt_after.tx_err_cnt <= err_cnt_before.tx_err_cnt) {
                 /* address claiming is finished */
                 k_event_post(&ts_can->events, EVENT_ADDRESS_CLAIMING_FINISHED);
-                LOG_INF("Using CAN node address 0x%.2X on %s", ts_can->node_addr, ts_can->dev->name);
+                LOG_INF("Using CAN node address 0x%.2X on %s", ts_can->node_addr, 
+                    ts_can->dev->name);
                 break;
             }
 

--- a/src/can.c
+++ b/src/can.c
@@ -685,7 +685,7 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
             if (err_cnt_after.tx_err_cnt <= err_cnt_before.tx_err_cnt) {
                 /* address claiming is finished */
                 k_event_post(&ts_can->events, EVENT_ADDRESS_CLAIMING_FINISHED);
-                LOG_INF("Using CAN node address 0x%.2X on %s", ts_can->node_addr, 
+                LOG_INF("Using CAN node address 0x%.2X on %s", ts_can->node_addr,
                         ts_can->dev->name);
                 break;
             }

--- a/src/can.c
+++ b/src/can.c
@@ -686,7 +686,7 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
                 /* address claiming is finished */
                 k_event_post(&ts_can->events, EVENT_ADDRESS_CLAIMING_FINISHED);
                 LOG_INF("Using CAN node address 0x%.2X on %s", ts_can->node_addr, 
-                    ts_can->dev->name);
+                        ts_can->dev->name);
                 break;
             }
 


### PR DESCRIPTION
Add name of CAN device to printout to make clearer when multiple CAN devices are in use