### PR TITLE
LoRaWAN: support ABP activation

### DIFF
--- a/include/thingset/sdk.h
+++ b/include/thingset/sdk.h
@@ -51,6 +51,10 @@ extern "C" {
 #define TS_ID_LORAWAN_JOIN_EUI  0x271
 #define TS_ID_LORAWAN_APP_KEY   0x272
 #define TS_ID_LORAWAN_DEV_NONCE 0x273
+#define TS_ID_LORAWAN_ABP       0x274
+#define TS_ID_LORAWAN_DEV_ADDR  0x275
+#define TS_ID_LORAWAN_APP_SKEY  0x276
+#define TS_ID_LORAWAN_NWK_SKEY  0x277
 
 /* Networking group items */
 #define TS_ID_NET                      0x28

--- a/src/Kconfig.lorawan
+++ b/src/Kconfig.lorawan
@@ -4,3 +4,12 @@
 config THINGSET_LORAWAN
 	depends on LORAWAN
 	bool "LoRaWAN interface"
+
+if THINGSET_LORAWAN
+
+config THINGSET_LORAWAN_ABP
+	bool "Support for ABP activation"
+	help
+	  Enable End-Device activation for Activation By Personalization(ABP).
+
+endif # THINGSET_LORAWAN


### PR DESCRIPTION
End device activation support for Activation By Personalization(ABP). Default ABP is disabled, set LoRaWAN data object pAbp to true to enable ABP and device address(pDevAddr), session keys for network(pNwkSKey) and application(pAppSKey).

Testing with Chirpstack network server for both OTAA and ABP can work fine.