### PR TITLE
[CAN] Added a boolean preset config for control messages. 

### DIFF
--- a/src/Kconfig.can
+++ b/src/Kconfig.can
@@ -91,6 +91,11 @@ config THINGSET_CAN_CONTROL_SUBSET
 	hex "Subset containing control data to be published"
 	depends on THINGSET_CAN_CONTROL_REPORTING
 
+config THINGSET_CAN_CONTROL_REPORTING_ENABLE_PRESET
+	bool "Control reporting broadcast will be enabled at boot time if set"
+	depends on THINGSET_CAN_CONTROL_REPORTING
+	default y
+
 config THINGSET_CAN_CONTROL_REPORTING_PERIOD
 	int "Control data reporting interval in milliseconds"
 	depends on THINGSET_CAN_CONTROL_REPORTING

--- a/src/can.c
+++ b/src/can.c
@@ -605,7 +605,7 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
     k_work_init_delayable(&ts_can->live_reporting_work, thingset_can_live_reporting_handler);
 #endif
 #ifdef CONFIG_THINGSET_CAN_CONTROL_REPORTING
-    ts_can->control_enable = IS_ENABLED(CONFIG_THINGSET_REPORTING_CONTROL_ENABLE_PRESET);
+    ts_can->control_enable = IS_ENABLED(CONFIG_THINGSET_CAN_CONTROL_REPORTING_ENABLE_PRESET);
     ts_can->control_period = CONFIG_THINGSET_CAN_CONTROL_REPORTING_PERIOD;
     k_work_init_delayable(&ts_can->control_reporting_work, thingset_can_control_reporting_handler);
 #endif


### PR DESCRIPTION
Fixes stupid mistake from my side in #56, I forgot to add the extra KCONFIG option to define if control broadcast is initiated at boot time or left to the user to be started using `ts_can->control_enable`. 