### PR TITLE
CAN: address claim enhancements

### DIFF
--- a/src/Kconfig.can
+++ b/src/Kconfig.can
@@ -11,6 +11,14 @@ menuconfig THINGSET_CAN
 
 if THINGSET_CAN
 
+config THINGSET_CAN_ADDR_MIN
+	int "CAN address range minimum"
+	default 1
+
+config THINGSET_CAN_ADDR_MAX
+	int "CAN address range maximum"
+	default 252
+
 config THINGSET_CAN_RX_BUF_SIZE
 	int "ThingSet CAN RX buffer size"
 	range 64 2048
@@ -187,5 +195,9 @@ config THINGSET_CAN_THREAD_PRIORITY
 	  via CAN ISO-TP.
 
 	  Only available for single-instance implementation.
+
+config THINGSET_CAN_SAVE_ADDR_ON_STARTUP
+	bool "ThingSet CAN persist CAN address on startup"
+	default y
 
 endif # THINGSET_CAN

--- a/src/can.c
+++ b/src/can.c
@@ -780,7 +780,7 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
                 LOG_WRN("Node addr already in use, trying 0x%.2X", ts_can->node_addr);
                 continue;
             }
-            if (!(event & EVENT_ADDRESS_CLAIM_MSG_SENT)) {
+            else if (!(event & EVENT_ADDRESS_CLAIM_MSG_SENT)) {
                 k_sleep(K_MSEC(100));
 
                 /**

--- a/src/can.c
+++ b/src/can.c
@@ -782,17 +782,6 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
             }
             else if (!(event & EVENT_ADDRESS_CLAIM_MSG_SENT)) {
                 k_sleep(K_MSEC(100));
-
-                /**
-                 * check for a timeout here to prevent an infinite loop in the case that discovery
-                 * frames transmit successfully but an address claim fails
-                 */
-                elapsed_ms += (k_uptime_get() - start);
-                if (timeout_ms > 0 && elapsed_ms > timeout_ms) {
-                    can_remove_rx_filter(ts_can->dev, filter_id);
-                    return -ETIMEDOUT;
-                }
-
                 continue;
             }
 

--- a/src/can.c
+++ b/src/can.c
@@ -745,17 +745,17 @@ int thingset_can_init_inst(struct thingset_can *ts_can, const struct device *can
         uint32_t event = k_event_wait(&ts_can->events,
                                       EVENT_ADDRESS_ALREADY_USED | EVENT_ADDRESS_CLAIM_TIMED_OUT,
                                       false, K_MSEC(500));
-        if (event & EVENT_ADDRESS_CLAIM_TIMED_OUT) {
-            LOG_ERR("Address claim timed out");
-            k_timer_stop(&ts_can->timeout_timer);
-            return -ETIMEDOUT;
-        }
-        else if (event & EVENT_ADDRESS_ALREADY_USED) {
+        if (event & EVENT_ADDRESS_ALREADY_USED) {
             /* try again with new random node_addr */
             ts_can->node_addr =
                 CONFIG_THINGSET_CAN_ADDR_MIN
                 + sys_rand32_get() % (CONFIG_THINGSET_CAN_ADDR_MAX - CONFIG_THINGSET_CAN_ADDR_MIN);
             LOG_WRN("Node addr already in use, trying 0x%.2X", ts_can->node_addr);
+        }
+        else if (event & EVENT_ADDRESS_CLAIM_TIMED_OUT) {
+            LOG_ERR("Address claim timed out");
+            k_timer_stop(&ts_can->timeout_timer);
+            return -ETIMEDOUT;
         }
         else {
             struct can_bus_err_cnt err_cnt_before;


### PR DESCRIPTION
* support defining a fixed range for addresses
* fix various race conditions in highly contested claiming scenarios where two nodes could end up with the same address
* make CAN address saving configurable