### PR TITLE
Use new ID for live reporting period to ensure reset

### DIFF
--- a/include/thingset/sdk.h
+++ b/include/thingset/sdk.h
@@ -94,7 +94,7 @@ extern "C" {
 #define TS_ID_SUBSET_LIVE     0x31
 #define TS_ID_REP_LIVE        0x310
 #define TS_ID_REP_LIVE_ENABLE 0x311
-#define TS_ID_REP_LIVE_PERIOD 0x312
+#define TS_ID_REP_LIVE_PERIOD 0x313 // in ms (0x312 was used to store period in s)
 
 #define TS_NAME_SUBSET_SUMMARY   "mSummary"
 #define TS_ID_SUBSET_SUMMARY     0x32


### PR DESCRIPTION
The period was changed from seconds to milliseconds in b7b67f4. For devices which had their previous setting stored in flash or EEPROM, this led to publishing intervals of e.g. 1 ms instead of 1 s, which may completely block the MCU trying to publish the reports.

By using a new ID, the previously stored value is ignored and the default value is used instead.

CC @jalinei 