### PR TITLE
Fix for Next USB Device Stack

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -197,17 +197,13 @@ static void serial_rx_buf_put(uint8_t c)
 static void serial_rx_cb(const struct device *dev, void *user_data)
 {
     uint8_t c;
-    int num_bytes_read = 0;
 
     if (!uart_irq_update(uart_dev)) {
         return;
     }
 
-    while (uart_irq_rx_ready(uart_dev)) {
-        num_bytes_read = uart_fifo_read(uart_dev, &c, 1);
-        if (num_bytes_read == 0) {
-            break;
-        }
+    while (uart_irq_is_pending(uart_dev)) {
+        uart_fifo_read(uart_dev, &c, 1);
         serial_rx_buf_put(c);
     }
 }

--- a/src/serial.c
+++ b/src/serial.c
@@ -197,13 +197,17 @@ static void serial_rx_buf_put(uint8_t c)
 static void serial_rx_cb(const struct device *dev, void *user_data)
 {
     uint8_t c;
+    int num_bytes_read = 0;
 
     if (!uart_irq_update(uart_dev)) {
         return;
     }
 
     while (uart_irq_rx_ready(uart_dev)) {
-        uart_fifo_read(uart_dev, &c, 1);
+        num_bytes_read = uart_fifo_read(uart_dev, &c, 1);
+        if (num_bytes_read == 0) {
+            break;
+        }
         serial_rx_buf_put(c);
     }
 }


### PR DESCRIPTION
Next Device Stack behaves a little bit different from the previous one. The function uart_irq_rx_ready() returns always true and creates a dead-lock with the current implementation. 